### PR TITLE
Added ACCEPT to TEMPLATE using FW_SERVICES_ACCEPT

### DIFF
--- a/SuSEfirewall2
+++ b/SuSEfirewall2
@@ -1287,6 +1287,10 @@ parse_configurations()
 		eval FW_SERVICES_ACCEPT_RELATED_`cibiz $zone`="\"\$FW_SERVICES_ACCEPT_RELATED_`cibiz $zone` \$RELATED\""
 	    fi
 
+	    if [ -n "$ACCEPT" ]; then
+		eval FW_SERVICES_ACCEPT_`cibiz $zone`="\"\$FW_SERVICES_ACCEPT_`cibiz $zone` \$ACCEPT\""
+	    fi
+
 	    if [ -n "$MODULES" ]; then
 		eval FW_LOAD_MODULES="\"\$FW_LOAD_MODULES \$MODULES\""
 	    fi

--- a/SuSEfirewall2.service.TEMPLATE
+++ b/SuSEfirewall2.service.TEMPLATE
@@ -36,6 +36,13 @@ BROADCAST=""
 # IPv4 use 0.0.0.0/0
 RELATED=""
 
+# space separated list of net,protocol[,sport[,dport]]
+# sets FW_SERVICES_ACCEPT_*_EXT
+# Alternative to TCP,UDP,... variants above allowing to
+# open ports for IPv6 only or IPv4 only, using ::/0 or
+# 0.0.0.0/0 as net (source address net).
+ACCEPT=""
+
 # additional kernel modules needed for this service
 # see FW_LOAD_MODULES
 MODULES=""


### PR DESCRIPTION
Allows to open ports for IPv6 only or IPv4 only using
::/0 or 0.0.0.0/0 as net (source address net) in same
way as the RELATED variable.
