### PR TITLE
SuSEfirewall2{,_init}.service: Conflict with firewalld service

### DIFF
--- a/SuSEfirewall2.service
+++ b/SuSEfirewall2.service
@@ -2,6 +2,7 @@
 Description=SuSEfirewall2 phase 2
 After=network.target ypbind.service nfs.service nfsserver.service rpcbind.service SuSEfirewall2_init.service
 Wants=SuSEfirewall2_init.service
+Conflicts=firewalld.service
 
 [Service]
 ExecStart=/usr/sbin/SuSEfirewall2 boot_setup

--- a/SuSEfirewall2_init.service
+++ b/SuSEfirewall2_init.service
@@ -2,6 +2,7 @@
 Description=SuSEfirewall2 phase 1
 Before=network.service
 Before=basic.target
+Conflicts=firewalld.service
 
 [Service]
 ExecStart=/usr/sbin/SuSEfirewall2 boot_init


### PR DESCRIPTION
SuSEfirewall2 and firewalld can't be run in parallel since they both
deploy iptables rules. Make the SuSEfirewall2 services conflict with
the firewalld one so we only have one firewall service running and
managing the iptables rules.