### PR TITLE
Order init Before network-pre on startup

### DIFF
--- a/SuSEfirewall2_init.service
+++ b/SuSEfirewall2_init.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=SuSEfirewall2 phase 1
-Before=network.service
+Before=network-pre.target network.service
 DefaultDependencies=false
 Requires=sysinit.target
 After=sysinit.target


### PR DESCRIPTION
Noticed that this is missing while changing order in wicked:
https://github.com/openSUSE/wicked/pull/824

Quote about network-pre from man systemd.special:
This passive target unit may be pulled in by services that want to run
before any network is set up, for example for the purpose of setting up
a firewall. All network management software orders itself after this
target, but does not pull it in.